### PR TITLE
💡 [feat] : 사용자 추가정보 등록 API 구현

### DIFF
--- a/src/main/java/com/KURUSH/KUFOREINER/matching/Matching.java
+++ b/src/main/java/com/KURUSH/KUFOREINER/matching/Matching.java
@@ -28,16 +28,20 @@ public class Matching {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long matchingId;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String nickname;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String nation;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String gender;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
+    private String colleage;
+
+
+    @Column(nullable = true)
     private String major;
 
     @ManyToOne

--- a/src/main/java/com/KURUSH/KUFOREINER/member/MemberService.java
+++ b/src/main/java/com/KURUSH/KUFOREINER/member/MemberService.java
@@ -1,16 +1,14 @@
 package com.KURUSH.KUFOREINER.member;
 
-import com.KURUSH.KUFOREINER.global.exception.HttpExceptionCode;
 import com.KURUSH.KUFOREINER.global.security.JWTUtil;
 import com.KURUSH.KUFOREINER.member.domain.Member;
+import com.KURUSH.KUFOREINER.member.dto.MemberInitialSettingsDTO;
 import com.KURUSH.KUFOREINER.member.dto.MemberJoinRequest;
-import com.KURUSH.KUFOREINER.member.exception.MemberExistException;
 import com.KURUSH.KUFOREINER.member.exception.NickNameAlreadyExistException;
 import com.KURUSH.KUFOREINER.member.exception.UserIdAlreadyExistException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 
@@ -43,6 +41,21 @@ public class MemberService {
         Member savedmember = memberRepository.save(member);
 
         return savedmember;
+    }
+    public MemberInitialSettingsDTO updateInitialSettings(MemberInitialSettingsDTO settingsDTO) {
+        Member member = memberRepository.findById(settingsDTO.getMemberId())
+
+                .orElseThrow(() -> new IllegalArgumentException("Member not found with id: " + settingsDTO.getMemberId()));
+
+        member.setColleage(settingsDTO.getColleage());
+        member.setMajor(settingsDTO.getMajor());
+        member.setStudentnumber(settingsDTO.getStudentNumber());
+        member.setNation(settingsDTO.getNation());
+        member.setLanguage(settingsDTO.getLanguage());
+        member.setSingularity(settingsDTO.getSingularity());
+
+        memberRepository.save(member);
+        return settingsDTO;
     }
 
 }

--- a/src/main/java/com/KURUSH/KUFOREINER/member/controller/MemberController.java
+++ b/src/main/java/com/KURUSH/KUFOREINER/member/controller/MemberController.java
@@ -2,8 +2,11 @@ package com.KURUSH.KUFOREINER.member.controller;
 
 import com.KURUSH.KUFOREINER.global.response.HttpResponse;
 import com.KURUSH.KUFOREINER.global.security.JWTUtil;
+import com.KURUSH.KUFOREINER.member.MemberRepository;
 import com.KURUSH.KUFOREINER.member.MemberService;
 import com.KURUSH.KUFOREINER.member.domain.Member;
+import com.KURUSH.KUFOREINER.member.dto.MemberInitialSettingsDTO;
+import com.KURUSH.KUFOREINER.member.dto.MemberInitialSettingsResponse;
 import com.KURUSH.KUFOREINER.member.dto.MemberJoinRequest;
 import com.KURUSH.KUFOREINER.member.dto.MemberJoinResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MemberController {
     private final MemberService memberService;
+    private final MemberRepository memberRepository;
     private final JWTUtil jwtUtil;
 
     @PostMapping("/join")
@@ -33,5 +37,15 @@ public class MemberController {
                 MemberJoinResponse.of(savedmember)
         );
     }
+
+    @PostMapping("/initial-settings")
+    @Operation(summary = "초기설정", description = "회원 초기설정을 실행합니다.")
+    public HttpResponse<MemberInitialSettingsResponse> setInitialSettings(@Valid @RequestBody MemberInitialSettingsDTO initialSettingsDTO) {
+        MemberInitialSettingsDTO savedSettings = memberService.updateInitialSettings(initialSettingsDTO);
+        return HttpResponse.okBuild(
+                MemberInitialSettingsResponse.of(savedSettings, "초기설정이 성공적으로 마무리되었습니다.")
+        );
+    }
+
 
 }

--- a/src/main/java/com/KURUSH/KUFOREINER/member/dto/MemberInitialSettingsDTO.java
+++ b/src/main/java/com/KURUSH/KUFOREINER/member/dto/MemberInitialSettingsDTO.java
@@ -1,0 +1,16 @@
+package com.KURUSH.KUFOREINER.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberInitialSettingsDTO {
+    private Long memberId;
+    private String colleage;
+    private String major;
+    private Long studentNumber;
+    private String nation;
+    private String language;
+    private String singularity;
+}

--- a/src/main/java/com/KURUSH/KUFOREINER/member/dto/MemberInitialSettingsResponse.java
+++ b/src/main/java/com/KURUSH/KUFOREINER/member/dto/MemberInitialSettingsResponse.java
@@ -1,0 +1,18 @@
+package com.KURUSH.KUFOREINER.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberInitialSettingsResponse {
+    private String message;
+    private MemberInitialSettingsDTO settings;
+
+    public static MemberInitialSettingsResponse of(MemberInitialSettingsDTO settings, String message) {
+        MemberInitialSettingsResponse response = new MemberInitialSettingsResponse();
+        response.setSettings(settings);
+        response.setMessage(message);
+        return response;
+    }
+}

--- a/src/main/java/com/KURUSH/KUFOREINER/member/dto/MemberJoinResponse.java
+++ b/src/main/java/com/KURUSH/KUFOREINER/member/dto/MemberJoinResponse.java
@@ -5,13 +5,14 @@ import lombok.Builder;
 
 @Builder
 public record MemberJoinResponse(
-        String surveyUrl,String message
+        Long memberId,String message
 
 
 ) {
 
     public static MemberJoinResponse of(Member member) {
         return MemberJoinResponse.builder()
+                .memberId(member.getMemberId())
                 .message(member.getNickname()+"님 회원가입을 축하합니다 !")
                 .build();
 


### PR DESCRIPTION


## 🔘Part

- [x] BE

  <br/>

## 🔎 작업 내용

우선 회원가입후 사용자으이 추가정보를 등록하는 기능을 구현하였습니다.

  <br/>

## 이미지 첨부

![image](https://github.com/KONKUK-HACKATON/Server/assets/58305106/0df6257a-4ee0-45ab-a1ca-03409f596429)

<br/>

## 🔧 앞으로의 과제
JWT를 이용한 매칭 게시판 등록 기능을 구현할 예정입니다.

  <br/>

## ➕ 이슈 링크

<br/>